### PR TITLE
chore: bump flint to 0.46.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The image must be built starting from a specific TFLint version.
 # ARGs are cleared after each FROM so we need to declare this here.
-ARG TFLINT_VERSION="v0.43.0"
+ARG TFLINT_VERSION="v0.46.1"
 
 # Use golang base image just to build our wrapper
 FROM golang:1.19-alpine as builder


### PR DESCRIPTION
(--recursive flag added in v0.44.0)